### PR TITLE
fix application.css

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,13 +2,3 @@
  *= require_tree .
  *= require_self
  */
-
-@import "pages/home.css";
-@import "custom.css";
-@import "maps.css";
-@import "_header.css";
-
-body {
-    margin: 0;
-    padding: 0;
-}


### PR DESCRIPTION
This pull request removes unused CSS imports and redundant styles in the `application.css` file to clean up the codebase.

Codebase cleanup:

* [`app/assets/stylesheets/application.css`](diffhunk://#diff-5bfcdc54bcda018d14515b827c80d9f9b8ee25704a4271b560a2f87439665f17L5-L14): Removed imports for `pages/home.css`, `custom.css`, `maps.css`, and `_header.css`, as well as the redundant `body` styles for margin and padding.