### PR TITLE
Remove redundant Home link from mobile nav

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,11 +19,6 @@
         <ul class="mobile-nav-list">
           <li>
             <%= link_to player_page_path, class: "mobile-nav-item" do %>
-              <i class="fas fa-home"></i> Home
-            <% end %>
-          </li>
-          <li>
-            <%= link_to player_page_path, class: "mobile-nav-item" do %>
               <i class="fas fa-music"></i> Player
             <% end %>
           </li>


### PR DESCRIPTION
This pull request modifies the mobile navigation menu in the `app/views/layouts/_header.html.erb` file. The "Home" link has been removed, leaving only the "Player" link in the mobile navigation list.Removes the duplicate "Home" link from the mobile navigation menu.

Both the "Home" and "Player" links pointed to the same page, so the redundant entry is removed to simplify the UI.