### PR TITLE
Enhance map styles and update cable schema by removing unused solid_c…

### DIFF
--- a/app/assets/stylesheets/maps.css
+++ b/app/assets/stylesheets/maps.css
@@ -5,7 +5,9 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  align-items: center; /* 子要素を中央揃えにする */
   padding-top: 70px;
+  gap: 20px; /* 要素間のスペースを追加 */
 }
 
 .map-wrapper {
@@ -27,7 +29,8 @@
 }
 
 .location-info {
-  width: 350px;
+  width: 100%; /* 横幅を親要素に合わせる */
+  max-width: 600px; /* 最大幅を地図と合わせる */
   background-color: #181818;
   color: #FFFFFF;
   padding: 20px;

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -40,16 +40,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_052726) do
     t.index ["user_id"], name: "index_playlists_on_user_id"
   end
 
-  create_table "solid_cable_messages", force: :cascade do |t|
-    t.binary "channel", limit: 1024, null: false
-    t.binary "payload", limit: 536870912, null: false
-    t.datetime "created_at", null: false
-    t.integer "channel_hash", limit: 8, null: false
-    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
-    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
-    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "uid"
     t.string "nickname"


### PR DESCRIPTION
This pull request includes updates to the `maps.css` file to enhance styling and responsiveness, as well as the removal of an unused database table from `cable_schema.rb`.

### Styling enhancements in `maps.css`:

* Centered child elements within the container using `align-items: center` and added spacing between elements with `gap: 20px`. (`[app/assets/stylesheets/maps.cssR8-R10](diffhunk://#diff-2220cb86a1a0f929f54315108ce4994276c152d3522186924ca014ef269f1817R8-R10)`)
* Updated `.location-info` to use a responsive width (`width: 100%`) with a maximum width of 600px for better alignment with the map. (`[app/assets/stylesheets/maps.cssL30-R33](diffhunk://#diff-2220cb86a1a0f929f54315108ce4994276c152d3522186924ca014ef269f1817L30-R33)`)

### Database schema cleanup:

* Removed the unused `solid_cable_messages` table from `db/cable_schema.rb`, including its columns and indexes. (`[db/cable_schema.rbL43-L52](diffhunk://#diff-2e83e0817676d7af7c816970587cc58ef43beec32194ea1c831423675f841810L43-L52)`)…able_messages table