### PR TITLE
feat: 地図画面に緯度経度の代わりに住所を表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "omniauth"
 gem "omniauth-spotify"
 gem "omniauth-rails_csrf_protection"
 gem "rspotify"
+gem "geocoder"
 gem "activerecord-session_store"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -131,6 +132,9 @@ GEM
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -446,6 +450,7 @@ DEPENDENCIES
   capybara
   debug
   dotenv-rails
+  geocoder
   importmap-rails
   jbuilder
   kamal

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -36,6 +36,24 @@ class LocationsController < ApplicationController
     end
   end
 
+  def reverse_geocode
+    lat = params[:latitude]
+    lng = params[:longitude]
+
+    if lat.blank? || lng.blank?
+      return render json: { error: 'Latitude and longitude are required' }, status: :bad_request
+    end
+
+    results = Geocoder.search([lat, lng])
+    address = results.first&.address
+
+    if address
+      render json: { address: address }
+    else
+      render json: { error: 'Address not found' }, status: :not_found
+    end
+  end
+
   private
 
   def location_params

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -19,6 +19,12 @@ class MapsController < ApplicationController
       }
     end
 
+    # 緯度経度から住所を取得
+    if @user_location[:latitude].present? && @user_location[:longitude].present?
+      results = Geocoder.search([@user_location[:latitude], @user_location[:longitude]])
+      @user_location[:address] = results.first.address if results.first
+    end
+
     # Spotifyプレイリストの取得
     if logged_in? && current_user.access_token.present?
       begin

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -51,7 +51,7 @@ export default class extends Controller {
         const longitude = position.coords.longitude;
         const accuracy = position.coords.accuracy;
 
-        this.updateLocationDisplay(latitude, longitude, accuracy);
+        
         this.sendLocationToServer(latitude, longitude);
 
         this.map.setView([latitude, longitude], 15);
@@ -70,11 +70,24 @@ export default class extends Controller {
         this.marker = L.marker([latitude, longitude], { icon: currentLocationIcon }).addTo(this.map)
           .bindPopup(`
             <div>
-              <strong>現在位置</strong><br>
-              緯度: ${latitude.toFixed(6)}<br>
-              経度: ${longitude.toFixed(6)}
+              <strong>登録位置</strong><br>
+              <span class="address-loading">住所を取得中...</span>
             </div>
           `).openPopup();
+
+        // 住所を取得してポップアップを更新
+        fetch(`/locations/reverse_geocode?latitude=${latitude}&longitude=${longitude}`)
+          .then(response => response.json())
+          .then(data => {
+            if (data.address) {
+              this.marker.getPopup().setContent(`
+                <div>
+                  <strong>現在位置</strong><br>
+                  ${data.address}
+                </div>
+              `);
+            }
+          });
 
         this.userLocationValue = {
           latitude: latitude,
@@ -153,20 +166,7 @@ export default class extends Controller {
     });
   }
 
-  updateLocationDisplay(lat, lng, accuracy) {
-    if (this.hasLocationDisplayTarget) {
-      this.locationDisplayTarget.innerHTML = `
-        <div class="coordinates">
-          <strong>緯度:</strong> ${lat.toFixed(4)}<br>
-          <strong>経度:</strong> ${lng.toFixed(4)}<br>
-          <strong>精度:</strong> ${Math.round(accuracy)}m
-        </div>
-        <div style="margin-top: 10px; font-size: 12px; color: #666;">
-          最終更新: ${new Date().toLocaleString('ja-JP')}
-        </div>
-      `;
-    }
-  }
+  
 
   showStatus(message, type) {
     if (this.hasStatusMessageTarget) {
@@ -205,14 +205,7 @@ export default class extends Controller {
     const playlistName = location.name || 'プレイリスト名不明';
     const playlistImage = location.playlist_image || null;
     
-    // デバッグ情報をコンソールに出力
-    console.log('Adding playlist marker:', {
-      name: location.name,
-      playlistName: playlistName,
-      userNickname: userNickname,
-      uri: location.uri,
-      playlistImage: playlistImage
-    });
+    
     
     // カスタムアイコン
     let markerOptions = {};

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -12,10 +12,9 @@
     <h3>位置情報</h3>
     <div data-map-target="locationDisplay" id="location-display">
       <% if @user_location && @user_location[:latitude].present? && @user_location[:longitude].present? %>
-        <div class="coordinates">
-          <strong>保存された位置:</strong><br>
-          緯度: <%= @user_location[:latitude].round(4) %><br>
-          経度: <%= @user_location[:longitude].round(4) %>
+        <div class="address">
+          <strong>現在地:</strong><br>
+          <%= @user_location[:address] %>
         </div>
       <% else %>
         <div class="loading">

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,16 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :nominatim,
+  use_https: true,
+  language: :ja,
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling)
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
   get '/.well-known/appspecific/com.chrome.devtools.json', to: ->(env) { [204, {}, []] }
 
   root 'static_pages#home'
-  resources :locations, only: [:show, :update]
+  resources :locations, only: [:show, :update] do
+    collection do
+      get :reverse_geocode
+    end
+  end
   
   # OmniAuth routes
   get '/auth/:provider/callback', to: 'sessions#create'


### PR DESCRIPTION
This pull request introduces geocoding functionality to the application, enabling reverse geocoding to convert latitude and longitude into human-readable addresses. Key changes include adding the `geocoder` gem, creating a new reverse geocoding endpoint, integrating geocoding into the front-end map display, and updating the user interface to show addresses instead of raw coordinates.

### Backend Changes: Geocoding Functionality
* Added the `geocoder` gem to the `Gemfile` and configured it in `config/initializers/geocoder.rb` to use the Nominatim service with Japanese language support. [[1]](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR8) [[2]](diffhunk://#diff-05e8472cf993db910196134bb3b173d9fdaeaf8374e00282b55486f30603f192R1-R16)
* Introduced a `reverse_geocode` action in `LocationsController` to handle reverse geocoding requests and return addresses based on latitude and longitude.
* Updated `MapsController#index` to perform reverse geocoding for the user's location and include the address in the response.
* Added a new route for the `reverse_geocode` action under the `locations` resource in `config/routes.rb`.

### Frontend Changes: Map and UI Updates
* Enhanced the map marker popup in `app/javascript/controllers/map_controller.js` to display the address retrieved via the new `reverse_geocode` endpoint.
* Removed the `updateLocationDisplay` method and its associated coordinate display functionality, as the UI now focuses on showing addresses. [[1]](diffhunk://#diff-a120d35bb98e94b474ab21a86dba1cf56de9c31726cc6c8ae76b5a58b3b01d48L156-R169) [[2]](diffhunk://#diff-ed8cbbd9779900ec5be0008cb84e6ceb414bb13c4a2cd93d00ae9fb506ef18c8L15-R17)
* Updated the map view in `app/views/maps/index.html.erb` to display the user's address instead of latitude and longitude.

### Code Cleanup
* Removed debugging code from the `map_controller.js` file to streamline the implementation.