### PR TITLE
feat: Add Geocoder initializer configuration

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,17 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :nominatim,
+  use_https: true,
+  language: :ja,
+  http_headers: { "User-Agent" => "SMIPE" },
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling)
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+)


### PR DESCRIPTION
This pull request introduces a new configuration for the Geocoder gem in the application. The configuration specifies the geocoding service to use, enables HTTPS, sets the language to Japanese, and adds a custom HTTP header.

### Geocoder configuration updates:

* [`config/initializers/geocoder.rb`](diffhunk://#diff-05e8472cf993db910196134bb3b173d9fdaeaf8374e00282b55486f30603f192R1-R17): Configured Geocoder to use the `:nominatim` lookup service, enable HTTPS (`use_https: true`), set the language to Japanese (`language: :ja`), and include a custom `User-Agent` header (`http_headers: { "User-Agent" => "SMIPE" }`).This commit introduces a new initializer for Geocoder, configuring it to use the Nominatim service with Japanese language support and a custom User-Agent. The configuration includes options for HTTPS usage and potential caching, setting the stage for geocoding functionality in the application.